### PR TITLE
Remove the swift version specification

### DIFF
--- a/LicensePlistViewController.xcodeproj/project.pbxproj
+++ b/LicensePlistViewController.xcodeproj/project.pbxproj
@@ -314,6 +314,7 @@
 				SDKROOT = iphoneos;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 4.0;
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
 			};
@@ -370,6 +371,7 @@
 				SDKROOT = iphoneos;
 				SWIFT_COMPILATION_MODE = wholemodule;
 				SWIFT_OPTIMIZATION_LEVEL = "-O";
+				SWIFT_VERSION = 4.0;
 				VALIDATE_PRODUCT = YES;
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
@@ -397,7 +399,6 @@
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 4.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Debug;
@@ -422,7 +423,6 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.github.yhirano.LicensePlistViewContoller;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;
-				SWIFT_VERSION = 4.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Release;

--- a/LicensePlistViewController/Info.plist
+++ b/LicensePlistViewController/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0</string>
+	<string>1.0.1</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>NSPrincipalClass</key>


### PR DESCRIPTION
## Overview

Swift 4.1 was specified in the framework's Target, so even if carthage update was done with Xcode 10 & Swift 4.2 it was compiled with swift 4.1.

```sh
> xcode-select -p
/Applications/Xcode_10_GM_seed.app/Contents/Developer
> carthage update --no-use-binaries --platform iOS
```

```sh
// error log
Module compiled with Swift 4.1.2 can not be imported in Swift 4.2
```

## Change point

Stop the version specification of Swift with framework target and change it so that it conforms to swift version of project.
