### PR TITLE
Remove the top gap on tableview

### DIFF
--- a/LicensePlistViewController/LicensePlistViewController.swift
+++ b/LicensePlistViewController/LicensePlistViewController.swift
@@ -38,18 +38,18 @@ open class LicensePlistViewController: UITableViewController {
 
     public init(plistPath: String? = LicensePlistViewController.defaultPlistPath,
                 title: String? = LicensePlistViewController.defaultTitle) {
-        super.init(style: .grouped)
+        super.init(style: .plain)
         self.commonInit(plistPath: plistPath, title: title)
     }
 
     override init(nibName nibNameOrNil: String?, bundle nibBundleOrNil: Bundle?) {
-        super.init(style: .grouped)
+        super.init(style: .plain)
         self.commonInit(plistPath: LicensePlistViewController.defaultPlistPath,
                         title: LicensePlistViewController.defaultTitle)
     }
 
     public required init(coder aDecoder: NSCoder) {
-        super.init(style: .grouped)
+        super.init(style: .plain)
         self.commonInit(plistPath: LicensePlistViewController.defaultPlistPath,
                         title: LicensePlistViewController.defaultTitle)
     }
@@ -68,8 +68,20 @@ open class LicensePlistViewController: UITableViewController {
                 self.navigationItem.leftBarButtonItem = item
             }
         }
+        
+        customizeTableViewVisual()
     }
 
+    fileprivate func customizeTableViewVisual() {
+        assert(tableView.style == .plain, "This customization assumes that the table view style is plain.")
+        
+        // Hide empty cells on display
+        tableView.tableFooterView = UIView()
+        
+        // Show background as if the table view style is grouped, which has a slightly different color from cells
+        tableView.backgroundColor = .groupTableViewBackground
+    }
+    
     // MARK: - Actions
     
     @IBAction open func dismissViewController(_ sender: AnyObject) {


### PR DESCRIPTION
Using grouped style obviously has a better look since it provides a contrast between the cells and the background of the tableview itself. But unfortunately it also provides a gap on top, which pretends to show the section headers that actually don't exist.

This PR tries to remove that gap on top while still maintain the background color of the whole tableview by:

1. Setting the style of tableview to .plain so it hides the top section header
2. Setting the tableview background color manually to .grouped style background color

Result:

| Before | After |
| --- | --- |
| <img width="570" alt="スクリーンショット 2019-11-12 17 36 33" src="https://user-images.githubusercontent.com/3942121/68655576-98228b00-0573-11ea-9bbc-834862b4b54a.png"> | <img width="570" alt="スクリーンショット 2019-11-12 17 32 22" src="https://user-images.githubusercontent.com/3942121/68655603-a4a6e380-0573-11ea-9bca-ecaf8adc0a95.png"> |