### PR TITLE
Add SwiftPM support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,9 @@ xcuserdata/
 *.dSYM.zip
 *.dSYM
 
+# Swift Package Manager
+.build/
+
 # Carthage
 #
 # Add this line if you want to avoid checking in source code from Carthage dependencies.

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,28 @@
+// swift-tools-version:5.3
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+    name: "LicensePlistViewController",
+    platforms: [.iOS(.v9)],
+    products: [
+        // Products define the executables and libraries a package produces, and make them visible to other packages.
+        .library(
+            name: "LicensePlistViewController",
+            targets: ["LicensePlistViewController"]),
+    ],
+    dependencies: [
+        // Dependencies declare other packages that this package depends on.
+        // .package(url: /* package url */, from: "1.0.0"),
+    ],
+    targets: [
+        // Targets are the basic building blocks of a package. A target can define a module or a test suite.
+        // Targets can depend on other targets in this package, and on products in packages this package depends on.
+        .target(
+            name: "LicensePlistViewController",
+            path: "LicensePlistViewController",
+            exclude: ["Info.plist"]
+        ),
+    ]
+)

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ LicensePlistViewController
 [![Language: Swift 5.0](https://img.shields.io/badge/swift-5.0-4BC51D.svg?style=flat)](https://developer.apple.com/swift)
 [![Version](https://img.shields.io/cocoapods/v/LicensePlistViewController.svg?style=flat)](http://cocoadocs.org/docsets/LicensePlistViewController)
 [![Carthage compatible](https://img.shields.io/badge/Carthage-compatible-4BC51D.svg?style=flat)](https://github.com/hsylife/SwiftyPickerPopover)
+[![Swift Package Manager compatible](https://img.shields.io/badge/Swift%20Package%20Manager-compatible-brightgreen.svg)](https://github.com/apple/swift-package-manager)
 
 LicensePlistViewController is ViewController for [LicensePlist](https://github.com/mono0926/LicensePlist/).
 
@@ -36,6 +37,18 @@ Simply add the following line to your `Cartfile`:
 ```
 github "yhirano/LicensePlistViewController"
 ```
+
+### Swift Package Manager
+
+Simply add the following line to your `Package.swift`:
+
+```swift
+dependencies: [
+    .package(url: "https://github.com/yhirano/LicensePlistViewController.git", from: "2.1.3")
+]
+```
+
+Alternatively, you can add the package [directly via Xcode](https://developer.apple.com/documentation/xcode/adding_package_dependencies_to_your_app).
 
 ## Usage
 


### PR DESCRIPTION
I've added support for Swift Package Manager.

I've tested this to work on the latest stable Xcode (12.5). This should not break any other distribution methods (CocoaPods, Carthage).