### PR TITLE
UITableView.Style can be changed

### DIFF
--- a/LicensePlistViewController/LicensePlistViewController.swift
+++ b/LicensePlistViewController/LicensePlistViewController.swift
@@ -34,15 +34,17 @@ open class LicensePlistViewController: UITableViewController {
 
     public convenience init(fileNamed fileName: String,
                             title: String? = LicensePlistViewController.defaultTitle,
-                            headerHeight: CGFloat? = LicensePlistViewController.defaultHeaderHeight) {
+                            headerHeight: CGFloat? = LicensePlistViewController.defaultHeaderHeight,
+                            tableViewStyle: UITableView.Style = .grouped) {
         let path = Bundle.main.path(forResource: fileName, ofType: "plist")
-        self.init(plistPath: path, title: title, headerHeight: headerHeight)
+        self.init(plistPath: path, title: title, headerHeight: headerHeight, tableViewStyle: tableViewStyle)
     }
 
     public init(plistPath: String? = LicensePlistViewController.defaultPlistPath,
                 title: String? = LicensePlistViewController.defaultTitle,
-                headerHeight: CGFloat? = LicensePlistViewController.defaultHeaderHeight) {
-        super.init(style: .grouped)
+                headerHeight: CGFloat? = LicensePlistViewController.defaultHeaderHeight,
+                tableViewStyle: UITableView.Style = .grouped) {
+        super.init(style: tableViewStyle)
         self.commonInit(plistPath: plistPath, title: title, headerHeight: headerHeight)
     }
 


### PR DESCRIPTION
## overview

LicensePlistViewController's UITableView.Style can be changed to `.insetGrouped`.

This is a sample program for a case where you want to set `.insetGrouped`.

```swift
let vc = LicensePlistViewController(tableViewStyle: .insetGrouped)
navigationController?.pushViewController(vc, animated: true)
```

## screenshot

|  | before | after |
|:----|:----|:----|
| no option: `LicensePlistViewController()`  | <img src="https://user-images.githubusercontent.com/137952/176886902-309052d0-ee30-4eb3-b53c-704d446da4ea.png" width="320px" /> | <img src="https://user-images.githubusercontent.com/137952/176886571-5c89bd04-10df-4c2a-b683-5ba3578dbca9.png" width="320px" /> |
| `LicensePlistViewController(tableViewStyle: .grouped)` | <img src="" width="320px" /> | <img src="https://user-images.githubusercontent.com/137952/176886672-6985a949-327b-4383-8172-55a3a7357ff4.png" width="320px" /> |
| `LicensePlistViewController(tableViewStyle: .insetGrouped)` | <img src="" width="320px" /> | <img src="https://user-images.githubusercontent.com/137952/176886739-e413675a-c6a8-416f-bfdf-1a9aad0d0ffd.png" width="320px" /> |
