### PR TITLE
Support for Privacy Manifest

### DIFF
--- a/LicensePlistViewController.podspec
+++ b/LicensePlistViewController.podspec
@@ -10,4 +10,5 @@ Pod::Spec.new do |s|
   s.source_files  = "LicensePlistViewController/*.swift"
   s.swift_version = "5.0"
   s.requires_arc = true
+  s.resource_bundles = {"LicensePlistViewController" => ["LicensePlistViewController/PrivacyInfo.xcprivacy"]}
 end

--- a/LicensePlistViewController.xcodeproj/project.pbxproj
+++ b/LicensePlistViewController.xcodeproj/project.pbxproj
@@ -20,6 +20,7 @@
 		8E1830852107DBFB00352CF4 /* String+FilePath.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8E1830842107DBFB00352CF4 /* String+FilePath.swift */; };
 		8E1830A92107F82600352CF4 /* com.mono0926.LicensePlist in Resources */ = {isa = PBXBuildFile; fileRef = 8E1830A82107F82600352CF4 /* com.mono0926.LicensePlist */; };
 		8EECE97A21C6884000A78DF9 /* LicensePlistViewController.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8E18304C2107BBA000352CF4 /* LicensePlistViewController.framework */; };
+		AAF934DA2B90C8F200E1FFA4 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = AAF934D92B90C8F200E1FFA4 /* PrivacyInfo.xcprivacy */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -39,6 +40,7 @@
 		8E1830822107CB6B00352CF4 /* LicensePlistParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LicensePlistParser.swift; sourceTree = "<group>"; };
 		8E1830842107DBFB00352CF4 /* String+FilePath.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+FilePath.swift"; sourceTree = "<group>"; };
 		8E1830A82107F82600352CF4 /* com.mono0926.LicensePlist */ = {isa = PBXFileReference; lastKnownFileType = folder; path = com.mono0926.LicensePlist; sourceTree = "<group>"; };
+		AAF934D92B90C8F200E1FFA4 /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -88,6 +90,7 @@
 				8E18307E2107C50A00352CF4 /* Item.swift */,
 				8E1830842107DBFB00352CF4 /* String+FilePath.swift */,
 				8E1830502107BBA000352CF4 /* Info.plist */,
+				AAF934D92B90C8F200E1FFA4 /* PrivacyInfo.xcprivacy */,
 			);
 			path = LicensePlistViewController;
 			sourceTree = "<group>";
@@ -207,6 +210,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				AAF934DA2B90C8F200E1FFA4 /* PrivacyInfo.xcprivacy in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/LicensePlistViewController/PrivacyInfo.xcprivacy
+++ b/LicensePlistViewController/PrivacyInfo.xcprivacy
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSPrivacyTracking</key>
+	<false/>
+	<key>NSPrivacyCollectedDataTypes</key>
+	<array/>
+	<key>NSPrivacyTrackingDomains</key>
+	<array/>
+	<key>NSPrivacyAccessedAPITypes</key>
+	<array/>
+</dict>
+</plist>

--- a/Package.swift
+++ b/Package.swift
@@ -22,7 +22,8 @@ let package = Package(
         .target(
             name: "LicensePlistViewController",
             path: "LicensePlistViewController",
-            exclude: ["Info.plist"]
+            exclude: ["Info.plist"],
+            resources: [.copy("PrivacyInfo.xcprivacy")]
         ),
     ]
 )


### PR DESCRIPTION
Sorry. I can only use simple English. I use machine translation.

I have added PrivacyInfo.xcprivacy to LicensePlistViewController.

This Pull Request fixed the following items:
* Add PrivacyInfo.xcprivacy when installed from CocoaPods
* Add PrivacyInfo.xcprivacy when installed from Carthage
* Add PrivacyInfo.xcprivacy when installed from Swift PM

----
Original Text: 
LicensePlistViewControllerに PrivacyInfo.xcprivacy を追加しました。PrivacyInfo.xcprivacy の内容についてはプライバシー関連APIを利用していない [SVProgressHUD](https://github.com/SVProgressHUD/SVProgressHUD/blob/master/SVProgressHUD/PrivacyInfo.xcprivacy)を参考にしました。

* CocoaPodsからインストールした場合、PrivacyInfo.xcprivacy が追加されるようにした
* Carthageからインストールした場合、PrivacyInfo.xcprivacy が追加されるようにした
* Swift PMからインストールした場合、PrivacyInfo.xcprivacy が追加されるようにした